### PR TITLE
feat: 支持语句清空输入框

### DIFF
--- a/flybirds/core/dsl/globalization/i18n.py
+++ b/flybirds/core/dsl/globalization/i18n.py
@@ -128,6 +128,8 @@ step_language = {
         "in ocr[{selector}]input[{param2}]": ["在扫描文字[{selector}]中输入[{param2}]"],
         "clear [{selector}] and input[{param2}]": [
             "在[{selector}]中清空并输入[{param2}]"],
+         "clear input[{selector}]": [
+            "清空输入框[{selector}]"],    
         "element[{selector}]position not change in[{param2}]seconds": [
             "元素[{selector}]位置[{param2}]秒内未变动"
         ],

--- a/flybirds/core/dsl/step/element.py
+++ b/flybirds/core/dsl/step/element.py
@@ -474,6 +474,17 @@ def ele_clear_input(context, selector=None, param2=None):
     g_Context.step.ele_clear_input(context, selector, param2)
 
 
+@step("clear input[{selector}]")
+@ele_wrap
+def clear_input(context, selector=None):
+    """
+    Empty the selector element param1 and enter the value param2
+    :param context: step context
+    :param selector: locator string for selector element (or None).
+    """
+    g_Context.step.clear_input(context, selector)
+
+
 @step("from [{selector}] select [{param2}]")
 @ele_wrap
 def ele_select(context, selector=None, param2=None):

--- a/flybirds/core/plugin/plugins/default/web/element.py
+++ b/flybirds/core/plugin/plugins/default/web/element.py
@@ -182,6 +182,13 @@ class Element:
         locator.fill(param_2, timeout=timeout)
         return self.page.wait_for_timeout(100)
 
+    def clear_input(self, context, param_1):
+        locator, timeout = self.get_ele_locator(param_1)
+        locator.click(timeout=timeout)
+        locator.fill('', timeout=timeout)
+        return self.page.wait_for_timeout(100)
+
+
     def ele_slide(self, context, param_1, param_2, param_3):
         locator, timeout = self.get_ele_locator(param_1)
         box = locator.bounding_box(timeout=timeout)

--- a/flybirds/core/plugin/plugins/default/web/step.py
+++ b/flybirds/core/plugin/plugins/default/web/step.py
@@ -217,6 +217,11 @@ class Step:
         ele.clear_and_input(context, selector, param_2)
 
     @classmethod
+    def clear_input(cls, context, selector):
+        ele = gr.get_value("plugin_ele")
+        ele.clear_input(context, selector)
+
+    @classmethod
     def ele_swipe(cls, context, selector, param_2, param_3):
         ele = gr.get_value("plugin_ele")
         ele.ele_slide(context, selector, param_2, param_3)


### PR DESCRIPTION
feat: web 支持语句清空输入框

    场景: web清空输入框
    假如 跳转到[https://www.baidu.com/]
    而且 在[#kw]中输入[flybirds]
    那么 点击文案[百度一下]
    而且 等待[3]秒
    而且 清空输入框[#kw]