### PR TITLE
feat: 新增web 浏览器前进\浏览器后退\元素属性包含 不包含 文案属性包含 不包含

### DIFF
--- a/flybirds/core/dsl/globalization/i18n.py
+++ b/flybirds/core/dsl/globalization/i18n.py
@@ -93,7 +93,8 @@ step_language = {
         "get cookie": ["获取cookie"],
         "get local storage": ["获取local storage"],
         "get session storage": ["获取session storage"],
-        "return to previous page": ["返回上一页"],
+        "return to previous page": ["返回上一页", "浏览器后退"],
+        "browser forward": ["浏览器前进"],
         "go to home page": ["回到首页"],
         "logon account[{selector1}]password[{selector2}]": [
             "登录账号[{selector1}]密码[{selector2}]",
@@ -112,8 +113,20 @@ step_language = {
         "text[{selector}]property[{param2}]is {param3}": [
             "文案[{selector}]的属性[{param2}]为{param3}"
         ],
+        "text[{selector}]property[{param2}]include {param3}": [
+            "文案[{selector}]的属性[{param2}]包含{param3}"
+        ],
+        "text[{selector}]property[{param2}]not include {param3}": [
+            "文案[{selector}]的属性[{param2}]不包含{param3}"
+        ],
         "element[{selector}]property[{param2}]is {param3}": [
             "元素[{selector}]的属性[{param2}]为{param3}"
+        ],
+         "element[{selector}]property[{param2}]include {param3}": [
+            "元素[{selector}]的属性[{param2}]包含{param3}"
+        ],
+         "element[{selector}]property[{param2}]not include {param3}": [
+            "元素[{selector}]的属性[{param2}]不包含{param3}"
         ],
         "mouse hover[{selector}]": ["鼠标悬浮[{selector}]"],
         "click[{selector}]": ["点击[{selector}]"],

--- a/flybirds/core/dsl/step/element.py
+++ b/flybirds/core/dsl/step/element.py
@@ -24,6 +24,37 @@ def text_attr_equal(context, selector=None, param2=None, param3=None):
     g_Context.step.text_attr_equal(context, selector, param2, param3)
 
 
+@step("text[{selector}]property[{param2}]include {param3}")
+@VerifyStep()
+@ele_wrap
+def text_attr_container(context, selector=None, param2=None, param3=None):
+    """
+    Check if the value of the attribute param2 of the text element param1 in
+     the page is param3
+
+    :param context: step context
+    :param selector: locator string for text element (or None).
+    :param param2: attribute Name
+    :param param3: expected Value
+    """
+    g_Context.step.text_attr_container(context, selector, param2, param3)
+
+@step("text[{selector}]property[{param2}]not include {param3}")
+@VerifyStep()
+@ele_wrap
+def text_attr_not_container(context, selector=None, param2=None, param3=None):
+    """
+    Check if the value of the attribute param2 of the text element param1 in
+     the page is param3
+
+    :param context: step context
+    :param selector: locator string for text element (or None).
+    :param param2: attribute Name
+    :param param3: expected Value
+    """
+    g_Context.step.text_attr_not_container(context, selector, param2, param3)
+
+
 @step("element[{selector}]property[{param2}]is {param3}")
 @VerifyStep()
 @ele_wrap
@@ -38,6 +69,37 @@ def ele_attr_equal(context, selector=None, param2=None, param3=None):
     :param param3: expected Value
     """
     g_Context.step.ele_attr_equal(context, selector, param2, param3)
+
+@step("element[{selector}]property[{param2}]include {param3}")
+@VerifyStep()
+@ele_wrap
+def ele_attr_container(context, selector=None, param2=None, param3=None):
+    """
+    Check if the value of the attribute param2 of the selector element param1
+     in the page is param3
+
+    :param context: step context
+    :param selector: locator string for selector element (or None).
+    :param param2: attribute Name
+    :param param3: expected Value
+    """
+    g_Context.step.ele_attr_container(context, selector, param2, param3)
+
+
+@step("element[{selector}]property[{param2}]not include {param3}")
+@VerifyStep()
+@ele_wrap
+def ele_attr_not_container(context, selector=None, param2=None, param3=None):
+    """
+    Check if the value of the attribute param2 of the selector element param1
+     in the page is param3
+
+    :param context: step context
+    :param selector: locator string for selector element (or None).
+    :param param2: attribute Name
+    :param param3: expected Value
+    """
+    g_Context.step.ele_attr_not_container(context, selector, param2, param3)
 
 
 @step("mouse hover[{selector}]")

--- a/flybirds/core/dsl/step/page.py
+++ b/flybirds/core/dsl/step/page.py
@@ -62,6 +62,10 @@ def get_session_storage(context):
 def return_pre_page(context):
     g_Context.step.return_pre_page(context)
 
+@step("browser forward")
+def page_go_forward(context):
+    g_Context.step.page_go_forward(context)
+
 
 @step("go to home page")
 def to_app_home(context):

--- a/flybirds/core/plugin/plugins/default/web/element.py
+++ b/flybirds/core/plugin/plugins/default/web/element.py
@@ -253,11 +253,52 @@ class Element:
                                      deal_method)
         verify_helper.attr_equal(target_val, ele_attr)
 
+    def is_ele_attr_container(self, context, selector, attr_name, target_val):
+        param2_dict = params_to_dic(attr_name, "attrName")
+        target_attr = param2_dict["attrName"]
+
+        deal_method = None
+        params_deal_module = None
+        if "dealMethod" in param2_dict.keys():
+            deal_method = param2_dict["dealMethod"]
+            params_deal_module = gr.get_value("projectScript").params_deal
+
+        ele_attr = self.get_ele_attr(selector, target_attr, params_deal_module,
+                                     deal_method)
+        verify_helper.attr_container(target_val, ele_attr)
+
+    def is_ele_attr_not_container(self, context, selector, attr_name, target_val):
+        param2_dict = params_to_dic(attr_name, "attrName")
+        target_attr = param2_dict["attrName"]
+
+        deal_method = None
+        params_deal_module = None
+        if "dealMethod" in param2_dict.keys():
+            deal_method = param2_dict["dealMethod"]
+            params_deal_module = gr.get_value("projectScript").params_deal
+
+        ele_attr = self.get_ele_attr(selector, target_attr, params_deal_module,
+                                     deal_method)
+        verify_helper.attr_not_container(target_val, ele_attr)
+
+
     def is_text_attr_equal(self, context, text_selector, attr_name,
                            target_val):
         if 'text=' not in text_selector:
             text_selector = "text=" + text_selector
         self.is_ele_attr_equal(context, text_selector, attr_name, target_val)
+
+    def is_text_attr_container(self, context, text_selector, attr_name,
+                           target_val):
+        if 'text=' not in text_selector:
+            text_selector = "text=" + text_selector
+        self.is_ele_attr_container(context, text_selector, attr_name, target_val)
+
+    def is_text_attr_not_container(self, context, text_selector, attr_name,
+                           target_val):
+        if 'text=' not in text_selector:
+            text_selector = "text=" + text_selector
+        self.is_ele_attr_not_container(context, text_selector, attr_name, target_val)
 
     def is_parent_exist_child(self, context, parent_selector, child_selector):
         parent_locator, p_timeout = self.get_ele_locator(parent_selector)

--- a/flybirds/core/plugin/plugins/default/web/page.py
+++ b/flybirds/core/plugin/plugins/default/web/page.py
@@ -298,6 +298,9 @@ class Page:
     def return_pre_page(self, context):
         self.page.go_back()
 
+    def page_go_forward(self, context):
+        self.page.go_forward()
+
     def sleep(self, context, param):
         if is_number(param):
             self.page.wait_for_timeout(float(param) * 1000)

--- a/flybirds/core/plugin/plugins/default/web/step.py
+++ b/flybirds/core/plugin/plugins/default/web/step.py
@@ -85,6 +85,12 @@ class Step:
         page.return_pre_page(context)
 
     @classmethod
+    def page_go_forward(cls, context):
+        page = gr.get_value("plugin_page")
+        page.page_go_forward(context)
+
+
+    @classmethod
     def sleep(cls, context, param):
         page = gr.get_value("plugin_page")
         page.sleep(context, param)
@@ -256,11 +262,31 @@ class Step:
     def ele_attr_equal(cls, context, selector, param2, param3):
         ele = gr.get_value("plugin_ele")
         ele.is_ele_attr_equal(context, selector, param2, param3)
+    @classmethod
+    def ele_attr_container(cls, context, selector, param2, param3):
+        ele = gr.get_value("plugin_ele")
+        ele.is_ele_attr_container(context, selector, param2, param3)
+
+    @classmethod
+    def ele_attr_not_container(cls, context, selector, param2, param3):
+        ele = gr.get_value("plugin_ele")
+        ele.is_ele_attr_not_container(context, selector, param2, param3)
 
     @classmethod
     def text_attr_equal(cls, context, selector, param2, param3):
         ele = gr.get_value("plugin_ele")
         ele.is_text_attr_equal(context, selector, param2, param3)
+
+    @classmethod
+    def text_attr_container(cls, context, selector, param2, param3):
+        ele = gr.get_value("plugin_ele")
+        ele.is_text_attr_container(context, selector, param2, param3)
+
+    @classmethod
+    def text_attr_not_container(cls, context, selector, param2, param3):
+        ele = gr.get_value("plugin_ele")
+        ele.is_text_attr_not_container(context, selector, param2, param3)
+
 
     @classmethod
     def find_child_from_parent(cls, context, p_selector, c_selector):

--- a/flybirds/utils/verify_helper.py
+++ b/flybirds/utils/verify_helper.py
@@ -62,3 +62,27 @@ def attr_equal(o_attr, t_attr):
             o_attr, t_attr
         )
         raise FlybirdVerifyException(message)
+
+def attr_container(o_attr, t_attr):
+    """
+    Determine whether the attributes are equal
+    """
+    if o_attr == "[@@空@@]" or o_attr == "@@空@@":
+        o_attr = ""
+
+    if not (str(o_attr) in str(t_attr)):
+        message = "attr not contain, expect value include:{}," \
+                  " actual value:{}".format(str(o_attr), str(t_attr))
+        raise FlybirdVerifyException(message)
+
+def attr_not_container(o_attr, t_attr):
+    """
+    Determine whether the attributes are equal
+    """
+    if o_attr == "[@@空@@]" or o_attr == "@@空@@":
+        o_attr = ""
+
+    if (str(o_attr) in str(t_attr)):
+        message = "attr contain, expect value not include:{}," \
+                  " actual value:{}".format(str(o_attr), str(t_attr))
+        raise FlybirdVerifyException(message)


### PR DESCRIPTION
新增web端语句
1.浏览器前进
2.浏览器后退
3.文案[{selector}]的属性[{param2}]包含{param3}
4.文案[{selector}]的属性[{param2}]不包含{param3}
5.元素[{selector}]的属性[{param2}]为{param3}
6.元素[{selector}]的属性[{param2}]不包含{param3}