### PR TITLE
fix: 文案为处理验证前后空格

### DIFF
--- a/flybirds/utils/verify_helper.py
+++ b/flybirds/utils/verify_helper.py
@@ -2,8 +2,12 @@
 """
 equal includ helper
 """
+import re
 from flybirds.core.exceptions import FlybirdVerifyException
 
+def replace_func(match):
+    n = int(match.group(1))
+    return ' ' * n
 
 def text_equal(o_text, t_text):
     """
@@ -11,6 +15,13 @@ def text_equal(o_text, t_text):
     """
     if o_text == "[@@空@@]" or o_text == "@@空@@":
         o_text = ""
+        
+    # 正则替换前后空格
+    # 定义正则表达式和替换函数
+    pattern = re.compile(r'@@空,\s*(\d+)@@')
+    # 使用 sub 函数进行正则替换
+    o_text = pattern.sub(replace_func, o_text)
+
     if "(@#@换行#符号@#@)" in o_text:
         o_text = o_text.replace("(@#@换行#符号@#@)", "\n")
     if t_text is not None:


### PR DESCRIPTION
[{selector}]的文案为[{param2}] 验证param2前后有空格被ele_wrap去除的场景
例：
[selector]的文案为[@@空,1@@param2@@空,2@@] 
@@空,n@@，n为相应的数字